### PR TITLE
Fix visual issues with certain browser sizes

### DIFF
--- a/content/home/about.md
+++ b/content/home/about.md
@@ -10,6 +10,6 @@ weight = 1
 
 # About us
 
-<img src="/img/trip-2019.jpg" width="200" style="float:right; margin-left:35px; margin-bottom: 10px;" alt="The inaugural LSD Trip, September 2019" />
+<img src="/img/trip-2019.jpg" style="float:right; margin-left:35px; margin-bottom: 10px; height: auto; width: auto; max-width: 33%; min-width: 200px;" alt="The inaugural LSD Trip, September 2019" />
 
 The **Languages, Systems, and Data (LSD) Lab** at UC Santa Cruz is a loosely organized federation of [CSE](https://www.soe.ucsc.edu/departments/computer-science-and-engineering) students, researchers, and faculty, working in **programming languages**, **systems**, **databases**, and their intersections.  We aim to cultivate a community where all of these research traditions can intermingle and benefit from one another.

--- a/data/fonts/ucsc.toml
+++ b/data/fonts/ucsc.toml
@@ -14,4 +14,4 @@ mono_font = "Roboto Mono"
 
 # Font size
 font_size = "20"
-font_size_small = "16"
+font_size_small = "14"

--- a/layouts/partials/css/academic.css
+++ b/layouts/partials/css/academic.css
@@ -1264,7 +1264,7 @@ nav#navbar-main li {
   background-color: transparent;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1024px) {
   .navbar {
     min-height: 50px !important;
   }


### PR DESCRIPTION
This pull request includes some quick changes to fix some visual issues for a small range of browser sizes. 

* The group image is now larger and automatically scales up to 33% of its original size. Its minimum size is the previous size (200px). This might be a subjective choice, and can be understandably revoked if others feel differently about increasing the picture's size. 
* Within a range of browser sizes, before the menu options collapse into a dropdown, the "Languages, Systems, and Data Lab" title would become layered on top of the menu items. The maximum width before menu items collapse has been increased to fix this. 
* On mobile, the `small_font_size` is too large, and causes the "About Us" title to be covered. Changing `small_font_size` from 16px to 14px might fix this. Although, this has yet to be tested on mobile because I cannot easily build the site and see there. This has the effect of the global text size on desktop also changing to the new value, but it is only at browser sizes close to mobile and is likely not an issue for readability.

